### PR TITLE
Use a URL string for repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
   "scripts": {
     "test": "node_modules/mocha/bin/mocha"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/zeke/dimensions"
-  },
+  "repository": "https://github.com/zeke/dimensions",
   "keywords": [
     "image",
     "dimensions",


### PR DESCRIPTION
This updates the `repository` value in package.json to be a string instead of an object.

This PR was generated by https://github.com/zeke/fix-all-the-repositories